### PR TITLE
修复字符码运算符按 UTF-8 字节处理导致的中文输入失效

### DIFF
--- a/tjs2/tjsInterCodeExec.cpp
+++ b/tjs2/tjsInterCodeExec.cpp
@@ -2951,8 +2951,25 @@ void tTJSInterCodeContext::CharacterCodeOf(tTJSVariant& val)
     tTJSVariantString* str = val.AsString();
     if (str)
     {
-        const tjs_char* ch = (const tjs_char*)*str;
-        val = tTVInteger(ch[0]);
+        // tjs_char 在本移植中为 UTF-8 字节(typedef char tjs_char)。
+        // '#' 运算符须返回首字符的 Unicode 码点(与原版 UTF-16 语义一致)，
+        // 而非首字节——否则非 ASCII 字符(如中文)会被截成单字节，且在
+        // signed char 平台(iOS/macOS ARM64)得到负值，破坏 KAG 编辑框等
+        // 依赖 `#key >= 32` 的字符范围判断，导致中文无法输入。
+        const unsigned char* p = (const unsigned char*)(const tjs_char*)*str;
+        tjs_uint32 code;
+        if (p[0] < 0x80)
+            code = p[0];
+        else if (p[0] < 0xE0 && (p[1] & 0xC0) == 0x80)
+            code = ((p[0] & 0x1F) << 6) | (p[1] & 0x3F);
+        else if (p[0] < 0xF0 && (p[1] & 0xC0) == 0x80 && (p[2] & 0xC0) == 0x80)
+            code = ((tjs_uint32)(p[0] & 0x0F) << 12) | ((p[1] & 0x3F) << 6) | (p[2] & 0x3F);
+        else if ((p[1] & 0xC0) == 0x80 && (p[2] & 0xC0) == 0x80 && (p[3] & 0xC0) == 0x80)
+            code = ((tjs_uint32)(p[0] & 0x07) << 18) | ((tjs_uint32)(p[1] & 0x3F) << 12) |
+                   ((p[2] & 0x3F) << 6) | (p[3] & 0x3F);
+        else
+            code = 0; // 非法/不完整 UTF-8
+        val = tTVInteger(code);
         str->Release();
         return;
     }
@@ -2961,9 +2978,34 @@ void tTJSInterCodeContext::CharacterCodeOf(tTJSVariant& val)
 //---------------------------------------------------------------------------
 void tTJSInterCodeContext::CharacterCodeFrom(tTJSVariant& val)
 {
-    tjs_char ch[2];
-    ch[0] = static_cast<tjs_char>(val.AsInteger());
-    ch[1] = 0;
+    // '$' 运算符：把 Unicode 码点编码为 UTF-8(tjs_char=char)，与 '#'(CharacterCodeOf)
+    // 对称。原实现只存低字节，导致 $0x8FD9 生不出「这」等非 ASCII 字符。
+    tjs_uint32 code = (tjs_uint32)val.AsInteger();
+    tjs_char ch[5];
+    int n = 0;
+    if (code < 0x80)
+    {
+        ch[n++] = (tjs_char)code;
+    }
+    else if (code < 0x800)
+    {
+        ch[n++] = (tjs_char)(0xC0 | (code >> 6));
+        ch[n++] = (tjs_char)(0x80 | (code & 0x3F));
+    }
+    else if (code < 0x10000)
+    {
+        ch[n++] = (tjs_char)(0xE0 | (code >> 12));
+        ch[n++] = (tjs_char)(0x80 | ((code >> 6) & 0x3F));
+        ch[n++] = (tjs_char)(0x80 | (code & 0x3F));
+    }
+    else
+    {
+        ch[n++] = (tjs_char)(0xF0 | ((code >> 18) & 0x07));
+        ch[n++] = (tjs_char)(0x80 | ((code >> 12) & 0x3F));
+        ch[n++] = (tjs_char)(0x80 | ((code >> 6) & 0x3F));
+        ch[n++] = (tjs_char)(0x80 | (code & 0x3F));
+    }
+    ch[n] = 0;
     val = ch;
 }
 //---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

KAG 编辑框（`[edit]` / `EditLayer`）在 **Windows 和 iOS 上无法输入中文**，Android 正常。

## 根因

字符码运算符 `#`(`CharacterCodeOf`) 返回的是 UTF-8 **首字节**，而非字符的 Unicode 码点。

本移植 `typedef char tjs_char`（字符串内部为 UTF-8）。中文首字节 ≥ `0x80`，在 `char` 默认**有符号**的平台（Windows x86/x64 MSVC、iOS/macOS ARM64）会变成负值，导致 `system/EditLayer.tjs` 中的 `if(#key >= 32)` 把中文误判为控制字符丢弃；Android（ARM，`char` 为 unsigned）不受影响——这正是「Win/iOS 打不出中文、安卓正常」的原因。

SDL / 输入法层本身完全正常（`SDL_EVENT_TEXT_INPUT` 已把正确的 UTF-8 中文送达），问题纯在 TJS 虚拟机。

## 改动

`tjs2/tjsInterCodeExec.cpp`：

- **`CharacterCodeOf`（`#`）**：解码 UTF-8 首字符，返回完整 Unicode 码点，恢复原版 KiriKiri 的 UTF-16 字符码语义。
- **`CharacterCodeFrom`（`$`）**：对称修复，将码点编码为 UTF-8 多字节（原实现只存低字节，`$0x8FD9` 生不出「这」）。

## 测试

- signed char 平台（Windows / iOS）跑含 `[edit]` 的场景，中文可正常输入。
- ASCII 字符及 `#`/`$` 的既有行为不变，各平台一致。