### PR TITLE
fix: 修复D3D表情播放器触摸判定失效问题

### DIFF
--- a/plugins/DrawDeviceD3D/D3DEmotePlayer.cpp
+++ b/plugins/DrawDeviceD3D/D3DEmotePlayer.cpp
@@ -226,6 +226,71 @@ tjs_real D3DEmotePlayer::getVariable(tTJSString name)
     return 0;
 }
 
+bool D3DEmotePlayer::containsLabel(tTJSString label, tjs_real x, tjs_real y)
+{
+    if (Impl && Impl->Player)
+    {
+        // 调用方（脚本侧层）传入的 (x,y) 是经 revmtx 逆变换后的"层本地坐标"：
+        //   x2 = revmtx.a*x + revmtx.c*y + revmtx.tx
+        //   y2 = revmtx.b*x + revmtx.d*y + revmtx.ty
+        // 而引擎 shape 判定区域的收集空间是虚拟屏设备像素（左上原点、y 向下），
+        // 两者相差层的仿射变换，直接透传会导致判定区域与画面错位（层无变换时偏移半屏）。
+        // 这里用 Layer->Matrix（脚本 setMatrix 存入的同一矩阵，即 revmtx 的正变换）
+        // 把层本地坐标还原为 primary 中心坐标，再加半屏转成设备像素。
+        // Matrix 与 revmtx 严格互逆，缩放/旋转/剪切层均正确；层无变换时退化为 x + W/2。
+        float lx = (float)x, ly = (float)y;
+        float wx = lx, wy = ly;
+        if (Layer && Device)
+        {
+            wx = Layer->Matrix[0] * lx + Layer->Matrix[1] * ly + Layer->Matrix[12] +
+                 Device->GetWidth() * 0.5f;
+            wy = Layer->Matrix[4] * lx + Layer->Matrix[5] * ly + Layer->Matrix[13] +
+                 Device->GetHeight() * 0.5f;
+        }
+        return Impl->Player->containsLabel(label, wx, wy);
+    }
+    return false;
+}
+
+bool D3DEmotePlayer::contains(tjs_real x, tjs_real y)
+{
+    if (Impl && Impl->Player)
+    {
+        // 与 containsLabel 相同的坐标空间换算（层本地 → 设备像素）
+        float lx = (float)x, ly = (float)y;
+        float wx = lx, wy = ly;
+        if (Layer && Device)
+        {
+            wx = Layer->Matrix[0] * lx + Layer->Matrix[1] * ly + Layer->Matrix[12] +
+                 Device->GetWidth() * 0.5f;
+            wy = Layer->Matrix[4] * lx + Layer->Matrix[5] * ly + Layer->Matrix[13] +
+                 Device->GetHeight() * 0.5f;
+        }
+        return Impl->Player->contains(wx, wy);
+    }
+    return false;
+}
+
+tjs_error D3DEmotePlayer::cb_contains(
+    tTJSVariant* result, tjs_int numparams, tTJSVariant** param, D3DEmotePlayer* objthis)
+{
+    // contains(label, x, y)（带标签命中判定）/ contains(x, y) 两参分发
+    if (objthis == nullptr)
+        return TJS_E_FAIL;
+    if (numparams >= 3 && param[0]->Type() != tvtReal)
+    {
+        if (result)
+            *result = objthis->containsLabel(tTJSString(*param[0]), (tjs_real)*param[1],
+                                             (tjs_real)*param[2]);
+        return TJS_S_OK;
+    }
+    if (numparams < 2)
+        return TJS_E_BADPARAMCOUNT;
+    if (result)
+        *result = objthis->contains((tjs_real)*param[0], (tjs_real)*param[1]);
+    return TJS_S_OK;
+}
+
 void D3DEmotePlayer::startWind(tjs_real start, tjs_real goal, tjs_real speed, tjs_real powMin,
                                tjs_real powMax)
 {
@@ -441,7 +506,11 @@ void D3DEmotePlayer::DrawToTarget(void* target, void* maskTarget)
     tjs_int limitH = (tjs_int)((float)Device->GetHeight() / sy);
     tjs_int originX = Layer ? (tjs_int)(((float)Device->GetWidth() * 0.5f + Layer->Matrix[12]) / sx) : 0;
     tjs_int originY = Layer ? (tjs_int)(((float)Device->GetHeight() * 0.5f + Layer->Matrix[13]) / sy) : 0;
-    Impl->Player->drawToTarget(backend, target, maskTarget, true, limitW, limitH, originX, originY);
+    // 把真实渲染视口尺寸（设备宽高）传给 drawToTarget：
+    // shape 判定区域收集的 NDC→像素换算须与实际渲染视口一致，
+    // 否则判定区域与画面错位
+    Impl->Player->drawToTarget(backend, target, maskTarget, true, limitW, limitH, originX, originY,
+                               Device->GetWidth(), Device->GetHeight());
     Animating = Impl->Player->get_animating();
 }
 

--- a/plugins/DrawDeviceD3D/D3DEmotePlayer.h
+++ b/plugins/DrawDeviceD3D/D3DEmotePlayer.h
@@ -57,6 +57,14 @@ public:
     void startWind(tjs_real start, tjs_real goal, tjs_real speed, tjs_real powMin, tjs_real powMax);
     void stopWind();
 
+    // 触摸命中判定接口：脚本侧对层做触摸检测时调用 contains(label, x, y)。
+    // 此前无 contains 方法，脚本侧调用直接抛"成员不存在"，触摸判定完全失效。
+    // contains(label,x,y) 按指定 shape 判定层判定；contains(x,y) 遍历全部判定层
+    bool containsLabel(tTJSString label, tjs_real x, tjs_real y);
+    bool contains(tjs_real x, tjs_real y);
+    static tjs_error cb_contains(
+        tTJSVariant* result, tjs_int numparams, tTJSVariant** param, D3DEmotePlayer* objthis);
+
     void playTimeline(tTJSString name, tjs_int flags = 0);
     void stopTimeline(tTJSString name = "");
     void fadeOutTimeline(tTJSString name, tjs_real time = 0, tjs_real easing = 0);

--- a/plugins/DrawDeviceD3D/DrawDeviceD3D.cpp
+++ b/plugins/DrawDeviceD3D/DrawDeviceD3D.cpp
@@ -851,6 +851,25 @@ tTJSVariant DrawDeviceD3D::getPrimaryLayers()
     return tTJSVariant(arr, arr);
 }
 
+tTJSVariant DrawDeviceD3D::getChildren()
+{
+    // children 属性：返回设备上全部 D3DLayer 的脚本对象数组。
+    // 脚本侧用它（drawDevice.children*）+ 元素的 absolute 属性做命中判定排序，
+    // 元素是带 checkTouch 的脚本层。此前无此属性，脚本侧取不到 D3D 层，
+    // D3D 层上的触摸判定整体失效
+    iTJSDispatch2* arr = TJSCreateArrayObject();
+    tjs_int idx = 0;
+    for (auto* layer : D3DLayers)
+    {
+        if (layer && layer->ScriptObject)
+        {
+            tTJSVariant v(layer->ScriptObject, layer->ScriptObject);
+            arr->PropSetByNum(TJS_MEMBERENSURE, idx++, &v, arr);
+        }
+    }
+    return tTJSVariant(arr, arr);
+}
+
 // ===========================================================================
 // D3DLayer
 // ===========================================================================

--- a/plugins/DrawDeviceD3D/DrawDeviceD3D.h
+++ b/plugins/DrawDeviceD3D/DrawDeviceD3D.h
@@ -180,6 +180,10 @@ public:
     // ---- 内部 ----
     void RegisterD3DLayer(class D3DLayer* layer) { D3DLayers.push_back(layer); }
     void UnregisterD3DLayer(class D3DLayer* layer);
+    // children 属性：返回设备上全部 D3DLayer 的脚本对象数组。
+    // 脚本侧按 drawDevice.children* + 元素 absolute 属性做触摸命中判定排序；
+    // 缺失该属性时 D3D 层完全不参与触摸判定
+    tTJSVariant getChildren();
     krkrsdl3::iTVPRenderBackend* GetBackend() { return Backend; }
     tjs_int GetWidth() const { return Width; }
     tjs_int GetHeight() const { return Height; }

--- a/plugins/DrawDeviceD3D/DrawDeviceD3D_reg.cpp
+++ b/plugins/DrawDeviceD3D/DrawDeviceD3D_reg.cpp
@@ -24,6 +24,7 @@ NCB_REGISTER_CLASS(DrawDeviceD3D)
     NCB_PROPERTY(transState, getTransState, setTransState);
     NCB_PROPERTY(maskMode, getMaskMode, setMaskMode);
     NCB_PROPERTY_RO(primaryLayers, getPrimaryLayers);
+    NCB_PROPERTY_RO(children, getChildren); // 脚本侧层命中判定依赖该属性枚举 D3D 层
     NCB_METHOD(checkEnable);
     NCB_METHOD(getModule);
     NCB_METHOD(update);
@@ -56,6 +57,7 @@ NCB_REGISTER_CLASS(D3D)
     NCB_PROPERTY(transState, getTransState, setTransState);
     NCB_PROPERTY(maskMode, getMaskMode, setMaskMode);
     NCB_PROPERTY_RO(primaryLayers, getPrimaryLayers);
+    NCB_PROPERTY_RO(children, getChildren); // 脚本侧层命中判定依赖该属性枚举 D3D 层
     NCB_METHOD(checkEnable);
     NCB_METHOD(getModule);
     NCB_METHOD(update);
@@ -155,6 +157,9 @@ NCB_REGISTER_CLASS(D3DEmotePlayer)
     NCB_METHOD(setColor);
     NCB_METHOD(setVariable);
     NCB_METHOD(getVariable);
+    // contains(label, x, y)：触摸命中判定，脚本侧对层做触摸检测时调用；
+    // RawCallback 以兼容 contains(x, y) 两参形式
+    NCB_METHOD_RAW_CALLBACK(contains, &D3DEmotePlayer::cb_contains, 0);
     NCB_METHOD(startWind);
     NCB_METHOD(stopWind);
     NCB_METHOD(playTimeline);

--- a/plugins/emoteplayer/emotefile.cpp
+++ b/plugins/emoteplayer/emotefile.cpp
@@ -473,8 +473,19 @@ emoteframe::emoteframe(emotefile* filePtr, uint32_t startOffset) : _filePtr(file
                     src = "";
                 }
                 src += tmp;
-                filePtr->parseString(tmp, _rootData["icon"]);
-                src += "/" + tmp;
+                // icon 部分缺失时不拼接：shape 帧
+                //（content.src="shape/xxx"）没有 icon 成员，无条件拼接会产出
+                // "src/shape/xxx/" 悬空 '/' 的 src，破坏 shape 帧的类型识别
+                // 与判定区域收集
+                auto iconIt = _rootData.find("icon");
+                if (iconIt != _rootData.end())
+                {
+                    tmp.clear();
+                    if (filePtr->parseString(tmp, iconIt->second) && !tmp.empty())
+                    {
+                        src += "/" + tmp;
+                    }
+                }
                 src.erase(std::remove(src.begin(), src.end(), '\0'), src.end());
             }
         }

--- a/plugins/emoteplayer/emoteplayerclass.cpp
+++ b/plugins/emoteplayer/emoteplayerclass.cpp
@@ -909,7 +909,9 @@ void EmotePlayer::drawToTarget(krkrsdl3::iTVPRenderBackend* renderer,
                                tjs_int width,
                                tjs_int height,
                                tjs_int originX,
-                               tjs_int originY)
+                               tjs_int originY,
+                               tjs_int viewW,
+                               tjs_int viewH)
 {
     if (emtEngine._mainfile == nullptr || emtEngine._mainmotion == nullptr)
         return;
@@ -918,10 +920,13 @@ void EmotePlayer::drawToTarget(krkrsdl3::iTVPRenderBackend* renderer,
     // D3D 直通路径不经 draw()/ResetDrawArea()：_limitArea 必须在这里初始化，
     // 否则 progress() 因"区域为零"提前返回（动画不推进）、updateTransMat()
     // 投影矩阵退化（什么都不画）。只补区域/变换，不创建软渲染目标。
+    // 真实渲染视口尺寸 viewW/viewH 一并记录（shape 判定区域
+    // 收集的 NDC→像素换算基准，须与实际渲染视口一致）
     if (width > 0 && height > 0 &&
         (_limitArea.width == _limitArea.originX || _limitArea.height == _limitArea.originY ||
          _width != width || _height != height || _limitArea.originX != originX ||
-         _limitArea.originY != originY))
+         _limitArea.originY != originY || _limitArea.viewW != (float)viewW ||
+         _limitArea.viewH != (float)viewH))
     {
         _width = width;
         _height = height;
@@ -929,6 +934,8 @@ void EmotePlayer::drawToTarget(krkrsdl3::iTVPRenderBackend* renderer,
         _limitArea.originY = originY;
         _limitArea.width = width;
         _limitArea.height = height;
+        _limitArea.viewW = (float)viewW;
+        _limitArea.viewH = (float)viewH;
         if (emtEngine._mainfile != nullptr)
             _limitArea.zMax = emtEngine.getZMax() * 2;
         if (_limitArea.zMax < 30.0f)
@@ -1013,11 +1020,24 @@ void EmotePlayer::stopWind()
 }
 bool EmotePlayer::contains(tjs_real x, tjs_real y)
 {
+    // 先遍历全部 shape 判定层（无 label 过滤），再回退到
+    // icon 包围盒。此前只查 icon 包围盒，shape 判定层（触摸区）不参与判定
+    if (emtEngine.containsAnyShape((float)x, (float)y))
+        return true;
     if (emtEngine._mainMotionRef != nullptr)
-    {
         return emtEngine._mainMotionRef->contains(x, y);
-    }
     return false;
+}
+bool EmotePlayer::containsLabel(tTJSString label, tjs_real x, tjs_real y)
+{
+    // 在 progress 阶段收集的 shapeNodeAreas 中匹配 label 并做
+    // 点判定。坐标系约定：shapeNodeAreas 收集空间与调用方坐标统一在渲染视口
+    // 像素空间（虚拟屏坐标，Y 向下）——收集端 clip→像素用真实视口
+    //（limitArea.viewW/viewH）换算，镜像已包含在收集链的 attachMat 中，
+    // 因此此处对坐标纯透传
+    if (emtEngine._mainfile == nullptr || emtEngine._mainMotionRef == nullptr)
+        return false;
+    return emtEngine.containsLabel(label.AsStdString(), (float)x, (float)y);
 }
 void EmotePlayer::skip()
 {
@@ -1328,6 +1348,12 @@ void EmotePlayer::updateTransMat()
     _renderMethod.currAngle = currAngle;
     _renderMethod.currZx = currZx;
     _renderMethod.currZy = currZy;
+    // 记录根投影参照系（shape 判定区域 clip→像素换算所用，
+    // 须与 containsLabel 的判定使用同一 limitArea；未传真实视口时的回退基准）
+    _renderMethod.originX = _limitArea.originX;
+    _renderMethod.originY = _limitArea.originY;
+    _renderMethod.width = _limitArea.width;
+    _renderMethod.height = _limitArea.height;
 }
 void EmotePlayer::ResetDrawArea(tjs_int width, tjs_int height)
 {

--- a/plugins/emoteplayer/emoteplayerclass.h
+++ b/plugins/emoteplayer/emoteplayerclass.h
@@ -200,6 +200,9 @@ public:
     void startWind(tjs_real start, tjs_real goal, tjs_real speed, tjs_real powMin, tjs_real powMax);
     void stopWind();
     bool contains(tjs_real x, tjs_real y);
+    // 带标签命中判定；x/y 为调用方传入的设备像素坐标，
+    // engine 侧在 shapeNodeAreas 收集空间直接判定
+    bool containsLabel(tTJSString label, tjs_real x, tjs_real y);
 
     void skip();
     void skipToSync();
@@ -220,7 +223,9 @@ public:
                       tjs_int width = 0,
                       tjs_int height = 0,
                       tjs_int originX = 0,
-                      tjs_int originY = 0);
+                      tjs_int originY = 0,
+                      tjs_int viewW = 0,
+                      tjs_int viewH = 0);
     void playTimeline(tTJSString name, tjs_int flags = 0);
     void stopTimeline(tTJSString name = "");
     bool getTimelinePlaying(tTJSString name = "");
@@ -309,6 +314,8 @@ public:
     using EmotePlayer::setCameraOffset;
     using EmotePlayer::setColor;
     using EmotePlayer::setCoord;
+    using EmotePlayer::contains;
+    using EmotePlayer::containsLabel;
     using EmotePlayer::setDrawAffineTranslateMatrix;
     using EmotePlayer::setOuterForce;
     using EmotePlayer::setRotate;

--- a/plugins/emoteplayer/emoterunner.cpp
+++ b/plugins/emoteplayer/emoterunner.cpp
@@ -1,6 +1,7 @@
 #include "emoterunner.h"
 
 #include <cstdint>
+#include <functional> // std::function (containsAnyShape)
 
 #include "Platform.h"
 
@@ -185,6 +186,69 @@ static void evaluateSurfaceChain(
     outClipY = -trans.y;
 }
 
+// Shape(触摸判定层)专用变换：输出 shape 局部点(lx,ly) 经全链
+// 平移/旋转/缩放后的 clip 坐标。与 evaluateSurfaceChain 的区别：
+//  1. 不做 icon 的 origin 偏移与纹理尺寸归一化（shape 不是纹理）
+//  2. 不走 Bezier/UV 链（shape 不参与网格变形）
+//  3. 节点位置 = 纯 T(coord)*R(angle)*S(zx,zy) 链（按 inheritMask）作用下的结果
+// 局部点以 shape 中心为原点：(±width/2, ±height/2)
+static void evaluateShapePoint(
+    const std::vector<emoteRender>& renderMethod,
+    float lx, float ly,
+    float& outClipX, float& outClipY)
+{
+    glm::vec4 trans(lx, ly, 0.0f, 1.0f);
+    int surfaceCount = (int)renderMethod.size();
+    uint32_t currInheritMask = 0xFFFFFFF;
+    for (int i = surfaceCount - 1; i >= 0; i--)
+    {
+        currInheritMask &= renderMethod[i].currInheritMask;
+        glm::mat4 model(1.0f);
+        // 最内层(shape 自身): zx/zy 是尺寸定义(zx*16 已计入 width/height)，
+        // 只应用位置平移，不再缩放/旋转
+        if (i == surfaceCount - 1)
+        {
+            model = glm::translate(
+                model, glm::vec3(renderMethod[i].currCoordx, renderMethod[i].currCoordy, 0));
+        }
+        else
+        {
+            model = glm::translate(
+                model, glm::vec3(renderMethod[i].currCoordx, renderMethod[i].currCoordy, 0));
+            if ((currInheritMask & 0x10) == 0x10)
+                model = glm::rotate(model, glm::radians(renderMethod[i].currAngle),
+                                    glm::vec3(0.0f, 0.0f, 1.0f));
+            if ((currInheritMask & 0x20) == 0x20)
+                model = glm::scale(model, glm::vec3(renderMethod[i].currZx, 1.0f, 1.0f));
+            if ((currInheritMask & 0x40) == 0x40)
+                model = glm::scale(model, glm::vec3(1.0f, renderMethod[i].currZy, 1.0f));
+            if ((currInheritMask & 0x180) == 0x180)
+            {
+                model = glm::mat4(1.0f, renderMethod[i].currSy, 0.0f, 0.0f,
+                                  renderMethod[i].currSx, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,
+                                  0.0f, 0.0f, 0.0f, 0.0f, 1.0f) *
+                        model;
+            }
+            else if ((currInheritMask & 0x80) == 0x80)
+            {
+                model = glm::mat4(1.0f, 0.0f, 0.0f, 0.0f, renderMethod[i].currSx, 1.0f, 0.0f,
+                                  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f) *
+                        model;
+            }
+            else if ((currInheritMask & 0x100) == 0x100)
+            {
+                model = glm::mat4(1.0f, renderMethod[i].currSy, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+                                  0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f) *
+                        model;
+            }
+        }
+        trans = model * trans;
+        trans = glm::vec4(renderMethod[i].attachMat * trans);
+    }
+    outClipX = trans.x;
+    outClipY = -trans.y;
+}
+
 // Build subdivided mesh for a given icon node
 static void buildSubdivMesh(
     const std::vector<emoteRender>& renderMethod,
@@ -285,8 +349,30 @@ void emotenoderef::checkDrawStatus(float tick, std::vector<emoteRender>& renderL
 
     if (frame == nullptr || !frame->hasContent)
     {
-        isNeedDraw = false;
-        return;
+        // motion 末尾的"结束帧"（type0 无 content）被命中时
+        //（tick 超过 motion 末帧且无循环回绕），回退到最后一个有 content 的帧：
+        // 静态层（如触摸判定 shape）在任何 tick 下都应保持其几何；
+        // 中间的空帧仍保持"隐藏"语义。此前直接隐藏，导致主 motion 播完后
+        // 触摸判定层整体消失
+        emoteframe* saved = frame;
+        if (currFrameIdx != (size_t)-1 && currFrameIdx == currentNode->frameList.size() - 1)
+        {
+            for (int i = (int)currFrameIdx - 1; i >= 0; --i)
+            {
+                if (currentNode->frameList.at(i)->hasContent)
+                {
+                    frame = currentNode->frameList.at(i);
+                    break;
+                }
+            }
+        }
+        if (frame == nullptr || !frame->hasContent)
+        {
+            frame = saved;
+            isNeedDraw = false;
+            return;
+        }
+        nextframe = nullptr; // 静态保持，不再向后续帧插值
     }
     nextframe = nullptr;
     if (currFrameIdx >= 0 && currFrameIdx < currentNode->frameList.size() - 1)
@@ -298,6 +384,7 @@ void emotenoderef::checkDrawStatus(float tick, std::vector<emoteRender>& renderL
     isNeedDraw = true;
     isIcon = false;
     isLayout = false;
+    isShape = false;
     emoteicon* tmpic = currentNode-> _filePtr->findsourceByName(frame->src);
     if (tmpic == nullptr)
         currentMtn = refTop->findmotionByName(frame->src);
@@ -322,15 +409,32 @@ void emotenoderef::checkDrawStatus(float tick, std::vector<emoteRender>& renderL
     else if (currentMtn != nullptr || strcmp(frame->src.c_str(), "layout") == 0 ||
              strcmp(frame->src.c_str(), "clip") == 0)
     {
-        isLayout = true;
-
-        // 直接用父类提供的区域
-        if (width != lim.width || height != lim.height)
+        // 部分导出的 PSB 会剥离 shape 帧的 src 字段
+        //（content 仅剩 coord/mask/zx/zy），解析后 src 落到默认值 "layout"，
+        // 此前一律当 layout 处理，shape 节点（node type==1）的判定区域
+        // 收集不到。type==1 即 shape 层，按 shape 处理并记录判定区域
+        if (strcmp(frame->src.c_str(), "layout") == 0 && currentNode->type == 1)
         {
-            width = lim.width;
-            height = lim.height;
-            originX = lim.originX;
-            originY = lim.originY;
+            isShape = true;
+            isNeedDraw = false;
+            // shape 像素尺寸 = zx/zy * 16 (PSB 规范: 单元正方形为 16x16)
+            width = (tjs_real)frame->zx * 16.0;
+            height = (tjs_real)frame->zy * 16.0;
+            originX = width / 2;
+            originY = height / 2;
+        }
+        else
+        {
+            isLayout = true;
+
+            // 直接用父类提供的区域
+            if (width != lim.width || height != lim.height)
+            {
+                width = lim.width;
+                height = lim.height;
+                originX = lim.originX;
+                originY = lim.originY;
+            }
         }
     }
     else
@@ -338,6 +442,13 @@ void emotenoderef::checkDrawStatus(float tick, std::vector<emoteRender>& renderL
         std::istringstream iss(frame->src);
         std::string token;
         std::getline(iss, token, '/');
+        if (token == "src")
+        {
+            // emote 拼接前缀 "src/<type>/<name>"，跳过第一段。
+            // 此前直接拿 "src" 判类型，落入 unsupported 分支被丢弃，
+            // shape 判定层因此收集不到区域
+            std::getline(iss, token, '/');
+        }
         if (strcmp(token.c_str(), "blank") == 0)
         {
             std::getline(iss, token, ':');
@@ -363,6 +474,7 @@ void emotenoderef::checkDrawStatus(float tick, std::vector<emoteRender>& renderL
             // shape的像素尺寸 = zx/zy * 16 (PSB规范: 单元正方形为16x16)
             // shape子类型从src的第二部分获取: rect(默认)、circle、point、quad
             const tjs_real shapeUnit = 16.0;
+            isShape = true; // 标记 shape 判定层
             isNeedDraw = false;
             width = (tjs_real)frame->zx * shapeUnit;
             height = (tjs_real)frame->zy * shapeUnit;
@@ -587,7 +699,10 @@ void emotenoderef::progress(float tick, std::vector<emoteRender>& renderList, em
         }
 
         // shape节点: 将currZx/currZy重置为1，避免与width/height双重缩放(px = zx * shapeUnit * 1)
-        if (!isIcon && frame != nullptr && frame->src.rfind("shape/", 0) == 0)
+        // 判定条件由"src 以 shape/ 开头"改为统一的 isShape 标记
+        //（src 缺省的 shape 节点会被原条件漏掉，导致缩放双重叠加、
+        // 判定区域计算错误）
+        if (isShape)
         {
             currZx = 1.0f;
             currZy = 1.0f;
@@ -650,38 +765,83 @@ void emotenoderef::progress(float tick, std::vector<emoteRender>& renderList, em
 
     // 对于shape节点保存面积信息(用于contains检测和getLayerGetter的shape返回)
     // 注: shape节点可能没有hasContent，用src判断即可
-    if (!isIcon && frame != nullptr && refMtn != nullptr)
+    // 识别条件由"src 以 shape/ 开头"改为统一的 isShape 标记，
+    // 兼容 src 缺省（解析为 layout）的 shape 节点
+    if (isShape && frame != nullptr && refMtn != nullptr && renderMethod.size() > 0)
     {
-        std::string src(frame->src);
-        if (src.rfind("shape/", 0) == 0 && renderMethod.size() > 0)
         {
-            // 两个端点就够了
-            float ot1x, ot1y, ot2x, ot2y;
-            evaluateSurfaceChain(renderMethod, 0, 0, ot1x, ot1y);
-            evaluateSurfaceChain(renderMethod, 1, 1, ot2x, ot2y);
-            glm::vec2 pt1(0, 0), pt2(1, 1);
-            // 边界缩放（最外层 surface 输出 clip → screen）
-            pt1.x = (ot1x / 2.0 + 0.5) * currentNode->_filePtr->_screenSize.width;
-            pt1.y = (ot1y / 2.0 + 0.5) * currentNode->_filePtr->_screenSize.height;
-            pt2.x = (ot2x / 2.0 + 0.5) * currentNode->_filePtr->_screenSize.width;
-            pt2.y = (ot2y / 2.0 + 0.5) * currentNode->_filePtr->_screenSize.height;
-            // 保存区域(使用独立的shapeList，避免状态重复)
+            // shape 区域：局部四角 (±w/2, ±h/2) 经全链变换后取
+            // 包围盒。shape 的 origin 是中心(checkDrawStatus 中 originX=width/2)，
+            // 尺寸 = zx*16 × zy*16。此前用 evaluateSurfaceChain 的 (0,0)-(1,1)
+            // 两个 UV 端点 —— 该函数面向 icon 纹理（含 origin 偏移/Bezier/UV 链），
+            // 对非纹理的 shape 语义完全错误，算出的区域与实际位置不符
+            const float halfW = (float)(width * 0.5);
+            const float halfH = (float)(height * 0.5);
+            float cs[4][2] = {{-halfW, -halfH}, {halfW, -halfH}, {halfW, halfH}, {-halfW, halfH}};
+            float minX = 0, minY = 0, maxX = 0, maxY = 0;
+            // 提前声明：四角顶点在下方循环内直接写入 quad
             emoterect tmprect;
+            for (int ci = 0; ci < 4; ci++)
+            {
+                float ccx, ccy;
+                evaluateShapePoint(renderMethod, cs[ci][0], cs[ci][1], ccx, ccy);
+                // clip → 渲染视口像素（GL 视口变换）：tex = ((clipX+1)/2*W,
+                // (1-clipY_gl)/2*H)。evaluateShapePoint 输出的 ccy 已含
+                // shader 的 Y 取反（ccy = -clipY_gl），故 texY=(1+ccy)/2*H。
+                // 参照尺寸取根 renderMethod 携带的 limitArea（与根投影 ortho
+                // 一致），不能用本节点的 lim（那是父链局部区域）。
+                // 换算基准由 PSB 逻辑尺寸 _screenSize 改为真实
+                // 渲染视口（lim.viewW/viewH；未设置时回退根节点 width/height）。
+                // 两者不一致时（如拉伸/缩放渲染）判定区域与画面错位。
+                // 收集空间 = contains 输入空间 = 调用方传入的设备像素空间
+                const emoteRender& rootRm = renderMethod.front();
+                float vw = lim.viewW > 0.0f ? lim.viewW : rootRm.width;
+                float vh = lim.viewH > 0.0f ? lim.viewH : rootRm.height;
+                float px = (ccx / 2.0f + 0.5f) * vw;
+                float py = (1.0f + ccy) * 0.5f * vh;
+                // 保存变换后的实际四角（与 push 顺序一致），
+                // 供精确四边形判定使用（包围盒仅作 circle/point 参照）
+                tmprect.quad[ci][0] = px;
+                tmprect.quad[ci][1] = py;
+                if (ci == 0)
+                {
+                    minX = maxX = px;
+                    minY = maxY = py;
+                }
+                else
+                {
+                    minX = std::min(minX, px);
+                    maxX = std::max(maxX, px);
+                    minY = std::min(minY, py);
+                    maxY = std::max(maxY, py);
+                }
+            }
+            // 保存区域(使用独立的shapeList，避免状态重复)
+            // tmprect 已在四角循环前声明（quad 顶点在循环内写入）
             tmprect.label = currentNode->label;
-            tmprect.left = pt1.x;
-            tmprect.top = pt1.y;
-            tmprect.width = pt2.x - pt1.x;
-            tmprect.height = pt2.y - pt1.y;
+            tmprect.left = minX;
+            tmprect.top = minY;
+            tmprect.width = maxX - minX;
+            tmprect.height = maxY - minY;
             // 根据src后缀确定shape子类型: rect/circle/point/quad
-            std::string srcType = src.substr(6); // 去掉"shape/"
-            if (srcType == "circle")
-                tmprect.shapeType = 1;
-            else if (srcType == "point")
-                tmprect.shapeType = 0;
-            else if (srcType == "quad")
-                tmprect.shapeType = 3;
-            else
-                tmprect.shapeType = 2; // rect默认
+            //（src 缺失子类型信息时默认按 rect 处理）
+            std::string src(frame->src);
+            size_t shapePos = src.find("shape/");
+            if (shapePos != std::string::npos)
+            {
+                std::string srcType = src.substr(shapePos + 6);
+                while (!srcType.empty() &&
+                       (srcType.back() == '/' || srcType.back() == '\0'))
+                    srcType.pop_back();
+                if (srcType == "circle")
+                    tmprect.shapeType = 1;
+                else if (srcType == "point")
+                    tmprect.shapeType = 0;
+                else if (srcType == "quad")
+                    tmprect.shapeType = 3;
+                else
+                    tmprect.shapeType = 2; // rect默认
+            }
             refMtn->shapeNodeAreas.push_back(tmprect);
         }
     }
@@ -730,7 +890,14 @@ void emotenoderef::progress(float tick, std::vector<emoteRender>& renderList, em
             emotenoderef* childRef = refMtn->getNodeRef(ch);
             if (childRef)
             {
-                childRef->progress(tick, renderMethod, {originX, originY, width, height, lim.zMax});
+                // 子链 limit 必须透传渲染视口 viewW/viewH：
+                // shape 判定区域收集的 NDC→像素换算依赖 lim.viewW/viewH，
+                // 5 字段初始化列表会将其丢为 0，收集端回退到根节点 width/height
+                //（= limitW/limitH，层矩阵含缩放时 ≠ 真实视口），导致判定
+                // 区域整体缩小/错位
+                childRef->progress(tick, renderMethod,
+                                   {originX, originY, width, height, lim.zMax, lim.viewW,
+                                    lim.viewH});
                 shapeList.insert(shapeList.end(), childRef->getShapeList().begin(), childRef->getShapeList().end());
             }
         }
@@ -741,8 +908,9 @@ void emotenoderef::progress(float tick, std::vector<emoteRender>& renderList, em
             // 在引擎中创建持久化的子motion ref
             currentMtnRef = new emotemotionref(currentMtn, refTop, this);
             refMtn->_subMotionRefs.push_back(currentMtnRef);
+            // 同上：子 motion 链同样透传 viewW/viewH
             currentMtnRef->progress(tick + currTimeOffset, renderMethod,
-                            {originX, originY, width, height, lim.zMax});
+                            {originX, originY, width, height, lim.zMax, lim.viewW, lim.viewH});
             // 收集子motion的shape
             shapeList.insert(shapeList.end(), currentMtnRef->getShapeList().begin(),
                              currentMtnRef->getShapeList().end());
@@ -1465,5 +1633,102 @@ tjs_real emoteengine::getVariable(const std::string& name)
 }
 void emoteengine::updatePhysics(float tick)
 {
+}
+
+// ---- 触摸命中判定 ----
+// 点在四边形内判定（射线法 even-odd，支持凸/凹四边形）。顶点为收集时
+// 保存的变换后实际四角（quad），比包围盒精确 —— 包围盒会把旋转/斜切
+// 四边形外扩，判定层相邻时容易误命中
+static bool pointInQuad(const float quad[4][2], float x, float y)
+{
+    bool inside = false;
+    for (int i = 0, j = 3; i < 4; j = i++)
+    {
+        float xi = quad[i][0], yi = quad[i][1];
+        float xj = quad[j][0], yj = quad[j][1];
+        if (((yi > y) != (yj > y)) &&
+            (x < (xj - xi) * (y - yi) / (yj - yi) + xi))
+            inside = !inside;
+    }
+    return inside;
+}
+
+// 点在 shape 区域内判定（shapeType：1=circle 2=rect 3=quad 0=point）
+// rect/quad 统一用变换后四角做精确四边形判定；src 缺省时
+// shapeType 落到默认 rect，同样适用 —— 判定区域精确贴合
+// 变换后的真实形状，不再使用外扩包围盒
+static bool pointInEmoteShape(const emoterect& r, float x, float y)
+{
+    switch (r.shapeType)
+    {
+    case 1: // circle: 包围盒左上+宽高 → 圆心/半径
+    {
+        float cx = r.left + r.width * 0.5f;
+        float cy = r.top + r.height * 0.5f;
+        float rad = r.width * 0.5f;
+        float dx = x - cx, dy = y - cy;
+        return dx * dx + dy * dy <= rad * rad;
+    }
+    case 0: // point: 极小范围
+    {
+        float cx = r.left, cy = r.top;
+        float dx = x - cx, dy = y - cy;
+        return dx * dx + dy * dy <= 1.0f;
+    }
+    case 3: // quad
+    case 2: // rect（src 缺省时的默认值）
+    default:
+        // 精确四边形判定（变换后实际四角），替代外扩包围盒
+        return pointInQuad(r.quad, x, y);
+    }
+}
+
+static bool containsLabelRef(emotemotionref* ref, const std::string& label, float x, float y)
+{
+    if (ref == nullptr)
+        return false;
+    for (const auto& area : ref->shapeNodeAreas)
+    {
+        // PSB parseString 会把结尾 '\0' 一并存入 label（长度+1），
+        // 项目内其它 label 比较均用 strcmp（在 '\0' 处截断），此处保持一致；
+        // 若用 std::string 的 == 会因长度差永远不相等，导致命中判定全部落空
+        if (std::strcmp(area.label.c_str(), label.c_str()) == 0 &&
+            pointInEmoteShape(area, x, y))
+            return true;
+    }
+    for (auto* sub : ref->_subMotionRefs)
+    {
+        if (containsLabelRef(sub, label, x, y))
+            return true;
+    }
+    return false;
+}
+
+bool emoteengine::containsLabel(const std::string& label, float x, float y)
+{
+    return containsLabelRef(_mainMotionRef, label, x, y);
+}
+
+bool emoteengine::containsAnyShape(float x, float y)
+{
+    // 无 label 过滤：遍历全部 shape 判定层
+    std::function<bool(emotemotionref*)> walk =
+        [&](emotemotionref* ref) -> bool
+    {
+        if (ref == nullptr)
+            return false;
+        for (const auto& area : ref->shapeNodeAreas)
+        {
+            if (pointInEmoteShape(area, x, y))
+                return true;
+        }
+        for (auto* sub : ref->_subMotionRefs)
+        {
+            if (walk(sub))
+                return true;
+        }
+        return false;
+    };
+    return walk(_mainMotionRef);
 }
 }

--- a/plugins/emoteplayer/emoterunner.h
+++ b/plugins/emoteplayer/emoterunner.h
@@ -19,6 +19,11 @@ namespace emoteplayer
         float width = 0.0f;
         float height = 0.0f;
         float zMax = 0.0f;
+        // 实际渲染视口尺寸（可能与 width/height 不同）。
+        // shape 判定区域收集时的 NDC→像素换算必须使用实际视口尺寸，
+        // 否则判定区域与画面错位。0 表示回退到 width/height。
+        float viewW = 0.0f;
+        float viewH = 0.0f;
     };
     // shape类型(pointed从PSB node的"shape"字段, 或从frame->src推断)
     // 0=point 1=circle 2=rect(默认) 3=quad
@@ -30,6 +35,12 @@ namespace emoteplayer
         float width = 0;
         float height = 0;
         int shapeType = 2; // 默认rect
+        // shape 判定区域的变换后四角顶点（设备像素，顺时针）。
+        // 矩形 shape 经节点全链变换（旋转/缩放/剪切）后是任意四边形，
+        // 用包围盒判定会把区域外扩而误命中相邻区域，故保存实际四角
+        // 供 pointInEmoteShape 做精确四边形判定；circle/point 仍用
+        // left/top/width/height。
+        float quad[4][2] = {{0}};
     };
     struct emoteRender // 渲染方式
     {
@@ -93,6 +104,10 @@ namespace emoteplayer
         bool isNeedDraw = false;
         bool isIcon = false;
         bool isLayout = false;
+        // shape 判定层（触摸判定用）：src 以 "shape/" 开头，
+        // 或 src 缺省（部分导出的 PSB 剥离了 shape 帧的 src 字段，
+        // 解析后落到 layout）且 node type==1
+        bool isShape = false;
         emoteframe* frame = nullptr;
         emoteframe* nextframe = nullptr;
 
@@ -189,6 +204,12 @@ namespace emoteplayer
         void setVariable(const std::string& name, tjs_real value);
         tjs_real getVariable(const std::string& name);
         void updatePhysics(float tick);
+
+        // 触摸命中判定：x/y 为 shapeNodeAreas 的收集空间
+        //（渲染视口像素，左上原点、Y 向下）
+        bool containsLabel(const std::string& label, float x, float y);
+        // 无 label 过滤版：遍历全部 shape 判定层
+        bool containsAnyShape(float x, float y);
 
         // progress阶段创建的主motion ref(生命周期跨progress/draw)
         emotemotionref* _mainMotionRef = nullptr;


### PR DESCRIPTION
彻底打通emote触摸链路，修复 D3D 路径下 EmotePlayer 立绘的触摸命中判定链路。

内容：
原版在 D3D 绘制路径下触摸判定链路是断的：DrawDeviceD3D 没有
children 属性，脚本无法枚举 D3D 层；D3DEmotePlayer 没有 contains 方法，脚本调用直接抛"成员不存在"。即便绕过这两处，shape 判定层
的区域收集与命中判定也存在多处缺陷（区域算错、坐标系错位、
label 永不匹配、motion 播完后判定层消失等），判定结果不可用。

## 实现方式

触摸链路打通后为双向闭环：

收集侧（progress 阶段）：
checkDrawStatus 以统一 isShape 标记识别 shape 判定层（src 以
"shape/" 开头，或 src 缺省且 node type==1） →  evaluateShapePoint 将 shape 局部四角 (±w/2, ±h/2) 经节点全链变换（平移/旋转/缩放/
剪切，按 inheritMask）输出 clip 坐标  →  按真实渲染视口
（emotelimit 新增 viewW/viewH，全链透传）换算为设备像素，连同
node label 存入 shapeNodeAreas。

判定侧（脚本调用时）：
脚本触摸坐标（层本地） →  D3DEmotePlayer.contains 经
Layer->Matrix 正变换还原为设备像素  →  emoteengine::containsLabel / containsAnyShape 递归 shapeNodeAreas  →  label 用 strcmp 匹配 （兼容 PSB parseString 存入的结尾 '\0'） →  rect/quad 用变换后实际 四角做射线法精确判定（包围盒会把旋转/斜切四边形外扩导致误命中），
circle/point 仍用包围盒。

## 具体修复

- DrawDeviceD3D：新增 children 只读属性，返回全部 D3DLayer 脚本 对象数组，脚本侧命中判定排序可枚举 D3D 层。
- D3DEmotePlayer：新增 contains(label, x, y) / contains(x, y) 脚本方法（RawCallback 分发）；绘制时下传真实渲染视口尺寸。
- EmotePlayer：contains 先遍历 shape 判定层再回退 icon 包围盒； 新增 containsLabel；记录根投影参照系与真实视口。
- emoterunner：shape 区域改用专用变换 evaluateShapePoint 计算 （原用的 evaluateSurfaceChain 面向 icon 纹理，含 origin 偏移/ UV 链，对非纹理 shape 语义错误）；NDC → 像素换算基准由 PSB 逻辑 尺寸改为真实渲染视口，子链 limit 透传 viewW/viewH；motion 末尾 无 content 的结束帧回退到最后一个有 content 的帧，静态判定层 不再消失。
- emotefile：icon 成员缺失时不拼接 src，避免产生悬空 '/' 破坏 shape 帧类型识别。