### PR TITLE
修复立绘（EmotePlayer）非 D3D 路径与带旋转层的立绘触摸命中判定

### DIFF
--- a/plugins/DrawDeviceD3D/D3DEmotePlayer.cpp
+++ b/plugins/DrawDeviceD3D/D3DEmotePlayer.cpp
@@ -237,14 +237,18 @@ bool D3DEmotePlayer::containsLabel(tTJSString label, tjs_real x, tjs_real y)
         // 两者相差层的仿射变换，直接透传会导致判定区域与画面错位（层无变换时偏移半屏）。
         // 这里用 Layer->Matrix（脚本 setMatrix 存入的同一矩阵，即 revmtx 的正变换）
         // 把层本地坐标还原为 primary 中心坐标，再加半屏转成设备像素。
-        // Matrix 与 revmtx 严格互逆，缩放/旋转/剪切层均正确；层无变换时退化为 x + W/2。
+        // 矩阵为行向量约定（与 DrawDeviceD3D 渲染路径一致）：
+        //   X = m11*x + m21*y + m41, Y = m12*x + m22*y + m42
+        // 即 X 取 Matrix[0]/[4]/[12]，Y 取 Matrix[1]/[5]/[13]。
+        // 此前按列向量取 Matrix[1]/[4]，轴对齐层（无旋转，m12=m21=0）时
+        // 两者等价不出错；带旋转/斜切的层（如 NEKOPARA After）则判定错位。
         float lx = (float)x, ly = (float)y;
         float wx = lx, wy = ly;
         if (Layer && Device)
         {
-            wx = Layer->Matrix[0] * lx + Layer->Matrix[1] * ly + Layer->Matrix[12] +
+            wx = Layer->Matrix[0] * lx + Layer->Matrix[4] * ly + Layer->Matrix[12] +
                  Device->GetWidth() * 0.5f;
-            wy = Layer->Matrix[4] * lx + Layer->Matrix[5] * ly + Layer->Matrix[13] +
+            wy = Layer->Matrix[1] * lx + Layer->Matrix[5] * ly + Layer->Matrix[13] +
                  Device->GetHeight() * 0.5f;
         }
         return Impl->Player->containsLabel(label, wx, wy);
@@ -256,14 +260,14 @@ bool D3DEmotePlayer::contains(tjs_real x, tjs_real y)
 {
     if (Impl && Impl->Player)
     {
-        // 与 containsLabel 相同的坐标空间换算（层本地 → 设备像素）
+        // 与 containsLabel 相同的坐标空间换算（层本地 → 设备像素，行向量约定）
         float lx = (float)x, ly = (float)y;
         float wx = lx, wy = ly;
         if (Layer && Device)
         {
-            wx = Layer->Matrix[0] * lx + Layer->Matrix[1] * ly + Layer->Matrix[12] +
+            wx = Layer->Matrix[0] * lx + Layer->Matrix[4] * ly + Layer->Matrix[12] +
                  Device->GetWidth() * 0.5f;
-            wy = Layer->Matrix[4] * lx + Layer->Matrix[5] * ly + Layer->Matrix[13] +
+            wy = Layer->Matrix[1] * lx + Layer->Matrix[5] * ly + Layer->Matrix[13] +
                  Device->GetHeight() * 0.5f;
         }
         return Impl->Player->contains(wx, wy);

--- a/plugins/emoteplayer/emoteplayer.cpp
+++ b/plugins/emoteplayer/emoteplayer.cpp
@@ -64,7 +64,8 @@ NCB_REGISTER_SUBCLASS(EmotePlayer)
     NCB_METHOD(setCameraOffset);
     NCB_METHOD(startWind);
     NCB_METHOD(stopWind);
-    NCB_METHOD(contains);
+    // contains(label, x, y) / contains(x, y) 两参分发（见 EmotePlayer::cb_contains）
+    NCB_METHOD_RAW_CALLBACK(contains, &EmotePlayer::cb_contains, 0);
     NCB_METHOD(skip);
     NCB_METHOD(skipToSync);
     NCB_METHOD(pass);
@@ -117,7 +118,8 @@ NCB_REGISTER_SUBCLASS(Player)
     NCB_METHOD(setCameraOffset);
     NCB_METHOD(startWind);
     NCB_METHOD(stopWind);
-    NCB_METHOD(contains);
+    // contains(label, x, y) / contains(x, y) 两参分发（见 EmotePlayer::cb_contains）
+    NCB_METHOD_RAW_CALLBACK(contains, &Player::cb_contains, 0);
     NCB_METHOD(skip);
     NCB_METHOD(skipToSync);
     NCB_METHOD(stop);

--- a/plugins/emoteplayer/emoteplayerclass.cpp
+++ b/plugins/emoteplayer/emoteplayerclass.cpp
@@ -385,6 +385,18 @@ public:
         {
             if (numparams < 2)
                 return TJS_E_BADPARAMCOUNT;
+            // contains(label, x, y)：带标签命中判定（脚本 AffineSourceMotion::checkTouch
+            // 等 3 参数形式）。此前只按 2 参数处理，param[0]（标签字符串）被转成
+            // 数值 0 当作 x、真实 x 被当作 y、真实 y 被丢弃，导致带旋转层的
+            // 触摸判定永远失败（轴对齐层凑巧不受影响）
+            if (numparams >= 3 && param[0]->Type() != tvtReal)
+            {
+                if (result && _ptr)
+                    *result =
+                        _ptr->containsLabel(tTJSString(*param[0]), (tjs_real)*param[1],
+                                            (tjs_real)*param[2]);
+                return TJS_S_OK;
+            }
             tjs_real x = *param[0];
             tjs_real y = *param[1];
             if (result)
@@ -1030,14 +1042,51 @@ bool EmotePlayer::contains(tjs_real x, tjs_real y)
 }
 bool EmotePlayer::containsLabel(tTJSString label, tjs_real x, tjs_real y)
 {
-    // 在 progress 阶段收集的 shapeNodeAreas 中匹配 label 并做
-    // 点判定。坐标系约定：shapeNodeAreas 收集空间与调用方坐标统一在渲染视口
-    // 像素空间（虚拟屏坐标，Y 向下）——收集端 clip→像素用真实视口
-    //（limitArea.viewW/viewH）换算，镜像已包含在收集链的 attachMat 中，
-    // 因此此处对坐标纯透传
+    // 在 progress 阶段收集的 shapeNodeAreas 中匹配 label 并做点判定。
+    // 坐标系适配：非直通（软渲染）路径下，脚本坐标是经 revmtx 逆变换后的
+    // 模型本地空间（setDrawAffineTranslateMatrix 的输入空间），而判定区域
+    // 收集于仿射后的绘制空间（attachMat = 投影 * _affineTrans），因此
+    // 需先用 _affineTrans 正变换到绘制空间再比对。_affineTrans 为单位阵
+    //（直通/D3D 路径或未设置仿射）时无影响。
     if (emtEngine._mainfile == nullptr || emtEngine._mainMotionRef == nullptr)
         return false;
-    return emtEngine.containsLabel(label.AsStdString(), (float)x, (float)y);
+    float wx = (float)x, wy = (float)y;
+    {
+        // 单位阵检查（避免 glm 版本间 operator== 差异）
+        const glm::mat4& m = _affineTrans;
+        bool identity = m[0][0] == 1.0f && m[1][1] == 1.0f && m[2][2] == 1.0f &&
+                        m[3][3] == 1.0f && m[0][1] == 0.0f && m[1][0] == 0.0f &&
+                        m[3][0] == 0.0f && m[3][1] == 0.0f;
+        if (!identity)
+        {
+            float lx = wx, ly = wy;
+            wx = m[0][0] * lx + m[1][0] * ly + m[3][0];
+            wy = m[0][1] * lx + m[1][1] * ly + m[3][1];
+        }
+    }
+    return emtEngine.containsLabel(label.AsStdString(), wx, wy);
+}
+tjs_error EmotePlayer::cb_contains(
+    tTJSVariant* result, tjs_int numparams, tTJSVariant** param, EmotePlayer* objthis)
+{
+    // contains(label, x, y)（带标签命中判定，脚本 AffineSourceMotion::checkTouch
+    // 的 3 参数形式）/ contains(x, y)（遍历全部判定层）两参分发。
+    // 此前只注册了 2 参数绑定，3 参数调用的标签字符串被强制转成 0、
+    // 真实 x 被当作 y、真实 y 被丢弃，触摸判定永远失败
+    if (objthis == nullptr)
+        return TJS_E_FAIL;
+    if (numparams >= 3 && param[0]->Type() != tvtReal)
+    {
+        if (result)
+            *result = objthis->containsLabel(tTJSString(*param[0]), (tjs_real)*param[1],
+                                             (tjs_real)*param[2]);
+        return TJS_S_OK;
+    }
+    if (numparams < 2)
+        return TJS_E_BADPARAMCOUNT;
+    if (result)
+        *result = objthis->contains((tjs_real)*param[0], (tjs_real)*param[1]);
+    return TJS_S_OK;
 }
 void EmotePlayer::skip()
 {

--- a/plugins/emoteplayer/emoteplayerclass.h
+++ b/plugins/emoteplayer/emoteplayerclass.h
@@ -203,6 +203,10 @@ public:
     // 带标签命中判定；x/y 为调用方传入的设备像素坐标，
     // engine 侧在 shapeNodeAreas 收集空间直接判定
     bool containsLabel(tTJSString label, tjs_real x, tjs_real y);
+    // contains 的脚本绑定分发：contains(label, x, y)（带标签命中，3 参数）/
+    // contains(x, y)（遍历全部判定层，2 参数）
+    static tjs_error cb_contains(tTJSVariant* result, tjs_int numparams, tTJSVariant** param,
+                                 EmotePlayer* objthis);
 
     void skip();
     void skipToSync();
@@ -316,6 +320,11 @@ public:
     using EmotePlayer::setCoord;
     using EmotePlayer::contains;
     using EmotePlayer::containsLabel;
+    static tjs_error cb_contains(tTJSVariant* result, tjs_int numparams, tTJSVariant** param,
+                                 Player* objthis)
+    {
+        return EmotePlayer::cb_contains(result, numparams, param, objthis);
+    }
     using EmotePlayer::setDrawAffineTranslateMatrix;
     using EmotePlayer::setOuterForce;
     using EmotePlayer::setRotate;


### PR DESCRIPTION
修复立绘（EmotePlayer）非 D3D 路径与带旋转层的立绘触摸命中判定

## 概述

在 NEKOPARA After 中实测发现：进入游戏内置的触摸模式后，点击立绘
（头/胸/身体部位）没有任何反应。排查发现触摸命中判定链路存在三个
独立缺陷，涉及软渲染与 D3D 直通两条路径。前两作（NEKOPARA vol.0 /
Extra）未暴露问题，是因为其立绘层为轴对齐、单实例布局，恰好掩盖了
这些缺陷。

本 PR 以最小改动修复全部三处问题，不改变任何既有调用路径的行为。

## 根因分析

### 问题 1：原生 EmotePlayer 的 contains 只支持 2 参数调用（软渲染路径，主因）

软渲染路径下立绘触摸由脚本 `AffineSourceMotion::checkTouch` 驱动，
它调用的是 **3 参数形式**：

```tjs
_player.contains("hit_" + part, x, y)   # part ∈ {bust, head, body}
```

而原生类只注册了 2 参数绑定 `contains(x, y)`。ncbind 静默接受了
3 参数调用并做强制转换：

| 参数 | 期望 | 实际 |
|---|---|---|
| param[0] | x 坐标 | 标签字符串 `"hit_bust"` → 强转数字 = **0** |
| param[1] | y 坐标 | 真实的 **x** 坐标 |
| param[2] | — | 真实的 **y** 坐标被**丢弃** |

运行时日志证实：无论点击何处，判定始终收到 `x=0` 的假坐标，
判定永远失败。

### 问题 2：D3D 路径坐标换算的矩阵约定错误

`D3DEmotePlayer::containsLabel/contains` 将脚本层本地坐标还原为
设备像素时，按**列向量**约定读取层矩阵（X = m11·x + m12·y + m41）。
但脚本 `setMatrix` 与引擎渲染路径均为**行向量**约定
（X = m11·x + m21·y + m41，见 DrawDeviceD3D 的仿射合成分支）。
两者相差一个转置：

- 轴对齐层（无旋转）：m12 = m21 = 0，两种读法**等价**——前两作
  因此侥幸正确；
- 带旋转/斜切的层（After 大量使用）：交叉项非零，判定坐标错位。

### 问题 3：软渲染路径坐标空间不匹配

`containsLabel` 收到的坐标是脚本经 revmtx 逆变换后的**模型本地
空间**坐标（`setDrawAffineTranslateMatrix` 的输入空间），而判定
区域 `shapeNodeAreas` 收集于**仿射后**的绘制空间
（attachMat = 投影 × _affineTrans）。两者相差一次仿射变换，
必须先正变换再比对。

## 修改内容（4 个文件，+87/-23 行）

### 1. `plugins/DrawDeviceD3D/D3DEmotePlayer.cpp`

触摸坐标换算改为行向量约定，与渲染路径一致：

```diff
-            wx = Layer->Matrix[0] * lx + Layer->Matrix[1] * ly + Layer->Matrix[12] + ...
-            wy = Layer->Matrix[4] * lx + Layer->Matrix[5] * ly + Layer->Matrix[13] + ...
+            wx = Layer->Matrix[0] * lx + Layer->Matrix[4] * ly + Layer->Matrix[12] + ...
+            wy = Layer->Matrix[1] * lx + Layer->Matrix[5] * ly + Layer->Matrix[13] + ...
```

（`containsLabel` 与 `contains` 两处）

### 2. `plugins/emoteplayer/emoteplayer.cpp`

EmotePlayer 与 Player 两个类的 contains 注册由 `NCB_METHOD(contains)`
改为 `NCB_METHOD_RAW_CALLBACK(contains, &...::cb_contains, 0)`，
使绑定层可感知参数个数与类型。

### 3. `plugins/emoteplayer/emoteplayerclass.h`

新增 `EmotePlayer::cb_contains` 静态回调声明及 `Player::cb_contains`
转发。

### 4. `plugins/emoteplayer/emoteplayerclass.cpp`

- 新增 `EmotePlayer::cb_contains` 实现：按参数个数与首参类型分发
  `contains(label, x, y)`（3 参数）/ `contains(x, y)`（2 参数）。
- 旧式分发器（TmpMotionObj::FuncCall）同样补上 3 参数分支。
- `EmotePlayer::containsLabel` 增加坐标空间适配：坐标先经
  `_affineTrans` 正变换到绘制空间再与判定区域比对；`_affineTrans`
  为单位阵时跳过（零开销）。

## 兼容性说明（不影响引擎本身）

- **2 参数 contains 调用**：解析与行为与修改前完全一致；
- **_affineTrans 为单位阵**（D3D 直通路径、未调用
  setDrawAffineTranslateMatrix 的场景）：变换被跳过，零影响；
- **轴对齐立绘层**：新旧矩阵读法数学上等价，行为不变；
- 不新增、不删除、不改名任何脚本可见 API，仅修复既有调用的
  处理逻辑；
- 所有新增分支都以"脚本传入 3 参数"或"设置了仿射矩阵"为触发
  条件，未触发的路径与官方行为逐字节一致。

## 验证

- NEKOPARA **After**：进入触摸模式，头/胸/身体部位判定全部正常，
  抚摸反应（表情/语音/动作）正确触发；
- NEKOPARA **vol.0 / Extra**：回归测试通过，既有触摸行为不变。

备注：迟早有一天我会把这套计算删了，写一套更统一的。
