### PR TITLE
fix: 修复KR视频播放器崩溃与播片卡死

### DIFF
--- a/core/media/movie/MessageQueue.cpp
+++ b/core/media/movie/MessageQueue.cpp
@@ -80,14 +80,14 @@ MsgQueueReturnCode CDVDMessageQueue::Put(CDVDMsg* pMsg, int priority, bool front
 {
     tTJSUniqueLock lock(m_section);
 
+    if (!pMsg)
+    {
+        return MSGQ_INVALID_MSG;
+    }
     if (!m_bInitialized)
     {
         pMsg->Release();
         return MSGQ_NOT_INITIALIZED;
-    }
-    if (!pMsg)
-    {
-        return MSGQ_INVALID_MSG;
     }
 
     if (priority > 0)

--- a/core/media/movie/VideoPlayerVideo.cpp
+++ b/core/media/movie/VideoPlayerVideo.cpp
@@ -412,6 +412,11 @@ void CVideoPlayerVideo::Execute()
             }
             else
             {
+                // decoder input queue is full (EAGAIN): drain output first so the
+                // decoder can accept this packet on the next loop iteration
+                if (!ProcessDecoderOutput(frametime, pts))
+                    Sleep(1);
+                pMsg->AddRef();
                 m_messageQueue.Put(pMsg, 0, false);
             }
         }

--- a/environ/sdl3/sdl3_app.cpp
+++ b/environ/sdl3/sdl3_app.cpp
@@ -588,7 +588,10 @@ void SDL_AppQuit(void* appstate, SDL_AppResult result)
 
 void TVPSetWindowTitle(const char* title)
 {
-    SDL_SetWindowTitle(tvp_window, title);
+    if (!tvp_window)
+        return;
+    const char* override_title = SDL_getenv("KRKR_WINDOW_TITLE");
+    SDL_SetWindowTitle(tvp_window, (override_title && *override_title) ? override_title : title);
 }
 
 std::string TVPGetWindowTitle()


### PR DESCRIPTION
问题一：播放视频时机率性段错误（内存未崩时表现为 TJS::eTJSError）
- 崩溃点：CVideoPlayerVideo::Execute → CDVDMessageQueue::Get +444，
  即内联的 item.message->AddRef()，从已释放对象读取 vtable 后 blr 野指针
- 根因：Execute 在 AddData 失败把消息重新入队时漏了 pMsg->AddRef()。
  CDVDMessageQueue::Put() 会接管传入引用（AddRef 入列表 + Release 调用者引用），
  循环末尾又无条件 pMsg->Release()，引用计数被多减一次，
  消息对象在仍挂在队列中时就被析构，队列留下悬垂指针，
  下一次 Get 取出后 AddRef 踩到已释放内存
- 修复：重入队前补 pMsg->AddRef()，与 CVideoPlayerAudio 的既有写法一致

问题二：播片约 3 秒后画面卡死
- 现象：视频解码线程 100% 空转、画面定格，音频正常
- 根因：解码器输入队列满时 avcodec_send_packet 返回 EAGAIN，
  AddData 返回 false，Execute 只把包塞回队列、从不调用 ProcessDecoderOutput
  抽取解码输出，解码器永远腾不出输入空间，形成
  「取包 → AddData 失败 → 重入队」的死循环
- 修复：失败路径先 ProcessDecoderOutput 抽帧再重入队，无帧可抽时 Sleep(1)
  防止空转（音频播放器每次循环本就抽帧，故无此问题）

附带加固：
- CDVDMessageQueue::Put() 将空指针检查移到 m_bInitialized 判断之前，
  避免未初始化分支先解引用空指针

影响文件：
- core/media/movie/VideoPlayerVideo.cpp
- core/media/movie/MessageQueue.cpp

验证：
- 《虹色旋律》OP（1280x720 HEVC/WMV，9.8s）完整播放，
  帧 pts 推进至 9.13s、展示时钟同步至 9.02s；修复前 2~5 秒内必崩
  或播放到 3.1 秒后定格